### PR TITLE
[ORG-233] [internal] Falsche PR Base für Patch Releases bei nicht-linearer Versionierung

### DIFF
--- a/.github/workflows/release-actions-create-pr.yml
+++ b/.github/workflows/release-actions-create-pr.yml
@@ -50,11 +50,11 @@ jobs:
         env:
           CI_PROJECT_NAME: ${{ github.event.repository.name }}
           CI_BRANCH_NAME: ${{ github.ref_name }}
-      - name: Get version
-        id: get-version
-        run: echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
       - name: Create PR for release branch
-        run: gh pr create --base master --head ${{ github.ref }} --title "[release] ${{ github.event.repository.name }} ${{ steps.get-version.outputs.version }}" --body "" --assignee "${{ github.actor }}"
+        run: |
+          BASE_BRANCH=$(python ci-scripts/release_actions.py print-base-branch)
+          PR_TITLE="[release] ${{ github.event.repository.name }} $(cat VERSION))"
+          gh pr create --base $BASE_BRANCH --head ${{ github.ref }} --title "$PR_TITLE"  --body "" --assignee "${{ github.actor }}"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Approve PR

--- a/templates/org-release-actions.yml
+++ b/templates/org-release-actions.yml
@@ -1,4 +1,4 @@
-# Version: 2023-10-05
+# Version: 2023-10-26
 # This is an organization workflow, it should not be edited!
 # The original source is in the baltech-ag/ci-scripts repository in the templates folder
 # https://baltech-wiki.atlassian.net/wiki/spaces/THIR/pages/257785857/GitHub#GitHub-Workflows-f%C3%BCr-Releasemanagement-einrichten
@@ -12,6 +12,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'v[0-9]+.[0-9]+'
     types:
       - 'closed'
 jobs:


### PR DESCRIPTION
Der Base Branch der automatisch erstellten Release PRs war bisher immer master. Bei z.B. Release einer Patch Version der ToolSuite wurde die aktualisierte Version auf master gemerged, obwohl sie auf den Release Branch gemerged werden sollte.

ORG-233