### PR TITLE
[ORG-260][feature] Manuelles löschen des Release-Branches nicht mehr nötig, wenn erstellen des PRs fehlschlägt.

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -158,6 +158,9 @@ jobs:
           gh pr create --base ${{ needs.release-context.outputs.base-branch }} --head ${{ github.ref }} --title "$PR_TITLE"  --body "" --assignee "${{ github.actor }}"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Delete Release-Branch
+        run: git push origin --delete ${{ github.ref_name  }}
+        if: failure()
       - name: Approve PR
         run: gh pr review ${{ github.ref_name }} --approve
         env:


### PR DESCRIPTION
Wenn es ein Problem gibt, z.B. JIRA-Version nicht vorhanden, wird der Release-Branch automatisch gelöscht.
Dadurch muss nur noch das Problem behoben werden und es kann der Release-Branch erneut gepusht werden, ohne dass der branch auf dem remote manuell gelöscht werden muss.

ORG-260