### PR TITLE
[feature] GitHub Action snow-actions/qrcode aktualisiert

### DIFF
--- a/.github/workflows/jira-android-build.yml
+++ b/.github/workflows/jira-android-build.yml
@@ -45,7 +45,7 @@ jobs:
           echo "CI_COMMIT_SHA=" >> $GITHUB_ENV
           echo "CI_COMMIT_REF_NAME=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
       - name: Create QR code
-        uses: snow-actions/qrcode@v1.1.0
+        uses: snow-actions/qrcode@v1.2.0
         with:
           text: '${{ inputs.android-url }}'
           path: '${{ inputs.qrcode-filename }}'


### PR DESCRIPTION
Bisher wurde bei jedem Erstellen eines QR Codes eine Warnung unter dem Job angezeigt, dass eine alte Node.js Version benutzt wird:

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20.

Version 1.2.0 benutzt Node.js 20.