### PR TITLE
[internal] Update der GitHub-Runner Ubuntu Images.

### DIFF
--- a/.github/workflows/commit-msg-validate.yml
+++ b/.github/workflows/commit-msg-validate.yml
@@ -3,7 +3,7 @@ on:
 jobs:
   commit-msg-validate:
     name: Validate commit messages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/commit_msg_validate.yml
+++ b/.github/workflows/commit_msg_validate.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   commit-msg-validate:
     name: Validate commit messages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/jira-android-build.yml
+++ b/.github/workflows/jira-android-build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   jira-android-build:
     name: Comment on new Android build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/jira-pr.yml
+++ b/.github/workflows/jira-pr.yml
@@ -3,7 +3,7 @@ on:
 jobs:
   jira-integration-pr:
     name: Comment on new pull request
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/jira-push.yml
+++ b/.github/workflows/jira-push.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   jira-integration-push:
     name: Comment pushed commit messages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: inputs.if
     steps:
       - name: Checkout


### PR DESCRIPTION
GitHub stellt den Support der 20.04 Images ap 01.04.2024 ein.