### PR TITLE
[bugfix] Es wurden die falschen Installer beim Deployen kopiert

### DIFF
--- a/.github/workflows/release-actions-deploy-fileserver.yml
+++ b/.github/workflows/release-actions-deploy-fileserver.yml
@@ -19,6 +19,9 @@ jobs:
     name: Deploy build to OneDrive
     runs-on: [self-hosted, windows, onedrive]
     steps:
+      - name: Clean Up
+        shell: pwsh
+        run: rm .\artifacts -r -force
       - name: Download artifact
         id: download-artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Wenn das Verzeichnis, in welches die Artifakte gedownloaded wurden, nicht leer war, z.B. hat es noch einen Installer aus einem vorherigen Release enthalten, konnte es passieren, dass dieser alte Installer ins OneDrive kopiert wurde.

Nun wird sichergestellt, dass das Verzeichniss leer ist.