### PR TITLE
[bugfix] Bei commit messages mit doppelten Anführungszeichen (") hat apply-to nicht funktioniert.

### DIFF
--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -224,7 +224,6 @@ jobs:
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
       - name: Create PRs
         run: |
-          BODY="${{ github.event.pull_request.body }}"
           while IFS= read -r LINE; do
             if [[ $LINE =~ ^apply-to:[[:space:]]*([^[:space:]]+)[[:space:]]*$ ]]; then 
               TARGET=${BASH_REMATCH[1]}
@@ -236,11 +235,13 @@ jobs:
               git cherry-pick ${{ github.sha }}~${{ github.event.pull_request.commits }}..${{ github.sha }} --strategy=ort --strategy-option=theirs --empty=drop || draft_flag="--draft"
               git push --force origin HEAD
           
-              gh pr create --base $TARGET --head $BRANCH --title "${{ github.event.pull_request.title }} ($TARGET)"  --body "" --assignee "${{ github.actor }}" $draft_flag
+              gh pr create --base $TARGET --head $BRANCH --title "$PR_TITLE ($TARGET)"  --body "" --assignee "${{ github.actor }}" $draft_flag
             fi
-          done <<< "$BODY"
+          done <<< "$PR_BODY"
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
 
   closing-issues:
     name: Closes JIRA issues mentioned in the PR body


### PR DESCRIPTION
Werte aus dem Github-Context werden ohne Escaping in Scripts eingesetzt. Anführungszeichen schließen dann ungewollt, vorangegangene Anführungszeichen.

Der Wert aus dem GitHub-Context wird nun zuerst einer Umgebungsvariable zugewiesen, damit wird ein korrektes Escaping erreicht.