### PR TITLE
[ORG-313] snow-actions/qrcode durch inline Python QR-Code-Generierung ersetzt

### DIFF
--- a/+plans/ORG-313.01.replace-snow-actions-qrcode-with-inline-python-qr-generation.md
+++ b/+plans/ORG-313.01.replace-snow-actions-qrcode-with-inline-python-qr-generation.md
@@ -1,0 +1,44 @@
+# Replace `snow-actions/qrcode` with inline Python QR generation
+
+## Context
+
+ORG-313 requires migrating all GitHub Actions to Node 24 before 2026-06-02. The `snow-actions/qrcode@v1.2.0` action (used in `jira-android-build.yml`) is unmaintained — last updated 2 years ago, no Node 24 support, and 9-month response time on the previous upgrade. Rather than waiting or forking, we move QR generation into the existing `build_android_comment.py` script using the `qrcode` Python library with `uv run` and PEP 723 inline dependencies.
+
+Only consumer: `baltech-ag/MobileIDApp` (passes custom `qrcode-filename`).
+
+## Changes
+
+### 1. `build_android_comment.py`
+
+- Add PEP 723 inline script metadata (`# /// script`) declaring `qrcode[pil]` dependency
+- Add `import qrcode`
+- Add `generate_qr_code(url, output_path)` function using `qrcode.make(url).save(output_path)`
+- Call it from `create_comments()` before the return dict
+
+### 2. `.github/workflows/jira-android-build.yml`
+
+- Add `astral-sh/setup-uv@v8.0.0` step after checkout steps
+- Remove `snow-actions/qrcode@v1.2.0` step
+- Change `python ci-scripts/build_android_comment.py` to `uv run ci-scripts/build_android_comment.py`
+- Keep `qrcode-filename` input unchanged
+
+### No other files change
+
+`common.py`, `youtrack.py`, `actions/issue-comment/action.yaml` — all untouched.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `build_android_comment.py` | Add PEP 723 metadata, QR generation logic |
+| `.github/workflows/jira-android-build.yml` | Add setup-uv, remove snow-actions, use `uv run` |
+
+## Verification
+
+1. After merging to ci-scripts master, trigger a MobileIDApp build (or manually run its `repo-release-actions-deploy.yml`)
+2. Check the YouTrack comment on the relevant issue — it should contain a QR code image linking to the Play Store URL
+3. Verify the GitHub Actions log shows `uv run` installing `qrcode[pil]` and no Node 24 deprecation warnings
+
+## Open questions / Notes
+
+- **None** — all decisions resolved during interview

--- a/.github/workflows/jira-android-build.yml
+++ b/.github/workflows/jira-android-build.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           repository: baltech-ag/ci-scripts
           path: ci-scripts
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.0.0
       - name: Set default env
         run: |
           commits=$(
@@ -44,13 +46,8 @@ jobs:
           echo "CI_NUM_COMMITS=${{ github.event.pull_request.commits }}" >> $GITHUB_ENV
           echo "CI_COMMIT_SHA=" >> $GITHUB_ENV
           echo "CI_COMMIT_REF_NAME=${{ github.event.pull_request.base.ref }}" >> $GITHUB_ENV
-      - name: Create QR code
-        uses: snow-actions/qrcode@v1.2.0
-        with:
-          text: '${{ inputs.android-url }}'
-          path: '${{ inputs.qrcode-filename }}'
       - name: Build Comment
-        run: python ci-scripts/build_android_comment.py > comment.json
+        run: uv run ci-scripts/build_android_comment.py > comment.json
         env:
           CI_AUTHOR_NAME: '${{ github.actor }}'
           CI_REPO_URL: '${{ github.server_url }}/${{ github.repository }}'

--- a/build_android_comment.py
+++ b/build_android_comment.py
@@ -33,7 +33,7 @@ def convert_to_comment(author_name, project_name, repo_url, branch_name,
             f'<a href="{android_url}"><b>Android</b> test build</a> '
             f'for <a href="{repo_url}"><b>{project_name}</b></a> '
             f'on branch <b>{branch_name}</b>:<br><br>\n'
-            f'<img src="{android_qrcode}" width="100">')
+            f'![]({android_qrcode})')
 
 
 def create_comments():

--- a/build_android_comment.py
+++ b/build_android_comment.py
@@ -1,8 +1,16 @@
 #!python3
 # -*- coding: utf-8 -*-
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "qrcode[pil]",
+# ]
+# ///
 
 import os
 import json
+
+import qrcode
 
 from common import retrieve_commits, group_by_issue
 
@@ -46,6 +54,9 @@ def create_comments():
         env[ANDROID_URL],
         env[ANDROID_QRCODE],
     )
+
+    qrcode.make(env[ANDROID_URL]).save(env[ANDROID_QRCODE])
+    
     return {
         issue: {
             "comment": comment,


### PR DESCRIPTION
Unmaintained `snow-actions/qrcode` Action entfernt und QR-Code-Generierung direkt in `build_android_comment.py` integriert (via `qrcode[pil]` mit PEP 723 inline dependencies und `uv run`).

**Achtung:** `ref: ORG-313` im ci-scripts Checkout muss vor dem Merge entfernt werden.

ORG-313