### PR TITLE
Tickets werden bei PR-Erstellung auf "In Review" gesetzt

### DIFF
--- a/+plans/AUTO-REVIEW.01.set-issues-to-in-review-when-a-pr-is-opened.md
+++ b/+plans/AUTO-REVIEW.01.set-issues-to-in-review-when-a-pr-is-opened.md
@@ -1,0 +1,70 @@
+# Set issues to In Review when a PR is opened
+
+## Context
+
+Today a PR body line `closes: <ISSUE>` only has an effect when the PR is merged:
+the `closing-issues` job in `.github/workflows/release-actions.yml` parses the PR
+body and sets the issue State to `Closed (Done)`.
+
+The issue should already be moved to `In Review` while the review is pending:
+
+- PR opened and **not** a draft -> set issue to `In Review`
+- PR opened **as draft** -> do nothing, wait until the draft flag is removed
+  (GitHub event `pull_request` / action `ready_for_review`)
+
+## YouTrack State values
+
+The State bundle used by all baltech projects:
+`Open`, `In Progress`, `On Hold`, `In Review`, `Closed (Done)`,
+`Closed (Won't Do)`, `Closed (Duplicate)`, `Closed (No Action Required)`,
+`Closed (Cannot Reproduce)`
+
+So the review state is exactly `In Review`.
+
+## Changes
+
+### 1. `youtrack.py` - generic `set-state` command
+
+`close_issue()` already writes the State field, but its name only fits closing.
+Extract the actual field update into `set_state(issue, state)` and let
+`close_issue()` delegate to it (CLI subcommands `close-issue` / `issue-close`
+stay unchanged).
+
+Add CLI subcommand `set-state` with required `--issue` and `--state`.
+
+### 2. `.github/workflows/release-actions.yml` - new job `review-issues`
+
+Mirrors the existing `closing-issues` job, but runs on PR open / ready-for-review
+and sets `In Review` instead of closing:
+
+```yaml
+if: >-
+  github.event_name == 'pull_request' &&
+  (github.event.action == 'ready_for_review' ||
+   (github.event.action == 'opened' && github.event.pull_request.draft == false))
+```
+
+`closing-issues` stays untouched (its job name may be referenced by required
+status checks).
+
+### 3. `templates/org-release-actions.yml` - additional trigger types
+
+The `pull_request` trigger currently only listens to `closed`. Add `opened` and
+`ready_for_review` so the new job is triggered at all, and bump the
+`# Version:` header (the template hash check warns repos with an outdated copy).
+
+## Notes / non-goals
+
+- `converted_to_draft` does **not** move the issue back - a PR that goes back to
+  draft keeps the `In Review` state.
+- `reopened` is not handled either.
+- The extra trigger types also start the `release-context` job on every opened
+  PR. For a non-release branch this ends up in the `commit-pushed` fallback of
+  `print_release_context()`, which is harmless; all release jobs stay skipped
+  (`branch-created` / `pr-merged` conditions).
+
+## Files
+
+- **Modify:** `youtrack.py`
+- **Modify:** `.github/workflows/release-actions.yml`
+- **Modify:** `templates/org-release-actions.yml`

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -284,6 +284,40 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
 
+  review-issues:
+    name: Sets issues mentioned in the PR body to review
+    runs-on: ubuntu-24.04
+    # A PR that is opened as draft is not ready for review yet, it is handled
+    # when the draft flag is removed ('ready_for_review').
+    if: >-
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'ready_for_review' ||
+      (github.event.action == 'opened' && github.event.pull_request.draft == false))
+    steps:
+      - name: Checkout ci-scripts repository
+        uses: actions/checkout@v6
+        with:
+          repository: baltech-ag/ci-scripts
+          ref: ${{ inputs.ci-scripts-ref }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Set Issues to In Review
+        run: |
+          while IFS= read -r LINE; do
+            if [[ $LINE =~ ^closes:[[:space:]]*([A-Za-z]+-[0-9]+)[[:space:]]*$ ]]; then
+              ISSUE=${BASH_REMATCH[1]}
+              python youtrack.py \
+                --base-url="${{ vars.YOUTRACK_URL }}" \
+                --token="${{ secrets.YOUTRACK_TOKEN }}" \
+                set-state \
+                --issue=$ISSUE \
+                --state="In Review" || echo "::error::could not set $ISSUE to In Review"
+            fi
+          done <<< "$BODY"
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+
   closing-issues:
     name: Closes issues mentioned in the PR body
     runs-on: ubuntu-24.04

--- a/templates/org-release-actions.yml
+++ b/templates/org-release-actions.yml
@@ -1,4 +1,4 @@
-# Version: 2026-07-13
+# Version: 2026-07-28
 # This is an organization workflow, it should not be edited!
 # The original source is in the baltech-ag/ci-scripts repository in the templates folder
 # https://baltech-wiki.atlassian.net/wiki/spaces/THIR/pages/257785857/GitHub#GitHub-Workflows-f%C3%BCr-Releasemanagement-einrichten
@@ -11,6 +11,8 @@ on:
       - 'v[0-9]+.[0-9]+'
       - 'v[0-9][0-9][0-9][0-9]-[0-9]+.[0-9]+'
     types:
+      - 'opened'
+      - 'ready_for_review'
       - 'closed'
   create:
 jobs:

--- a/youtrack.py
+++ b/youtrack.py
@@ -313,8 +313,8 @@ class YouTrack:
             skip += batch_size
         return all_issues
 
-    def close_issue(self, issue: str, state: str = "Closed (Done)") -> None:
-        """Close an issue by updating its State field."""
+    def set_state(self, issue: str, state: str) -> None:
+        """Set the State field of an issue."""
         _assert_ok_status(
             self._request(
                 f"api/issues/{issue}",
@@ -331,6 +331,10 @@ class YouTrack:
                 }).encode()
             )
         )
+
+    def close_issue(self, issue: str, state: str = "Closed (Done)") -> None:
+        """Close an issue by setting its State field to a closed state."""
+        self.set_state(issue, state)
 
     def _request(
             self,
@@ -426,6 +430,11 @@ if __name__ == "__main__":
     close_issue_parser.set_defaults(func=YouTrack.close_issue)
     close_issue_parser.add_argument("--issue", required=True)
     close_issue_parser.add_argument("--state", default="Closed (Done)")
+
+    set_state_parser = subparsers.add_parser("set-state")
+    set_state_parser.set_defaults(func=YouTrack.set_state)
+    set_state_parser.add_argument("--issue", required=True)
+    set_state_parser.add_argument("--state", required=True)
 
     args = parser.parse_args().__dict__
 


### PR DESCRIPTION
Bisher hat ein `closes: <TICKET>`-Eintrag im PR-Body das Ticket nur beim Mergen
des PRs geschlossen. Jetzt wird das Ticket bereits waehrend des Reviews auf
"In Review" gesetzt:

- PR wird erstellt und ist **kein** Draft -> Ticket auf "In Review"
- PR wird als Draft erstellt -> es passiert nichts, bis das Draft-Flag entfernt
  wird (GitHub-Event `ready_for_review`)

Aenderungen:

- `youtrack.py`: das Setzen des State-Felds wurde aus `close_issue()` in ein
  generisches `set_state(issue, state)` herausgezogen, `close_issue()` ruft es
  nur noch auf. Neues CLI-Kommando `set-state`.
- `.github/workflows/release-actions.yml`: neuer Job `review-issues` neben dem
  bestehenden `closing-issues`. `closing-issues` bleibt unveraendert, da der
  Job-Name als Required-Status-Check referenziert sein kann.
- `templates/org-release-actions.yml`: der `pull_request`-Trigger horcht bisher
  nur auf `closed`, jetzt zusaetzlich auf `opened` und `ready_for_review`.

Wichtig: die neue Funktion greift in einem Repository erst, wenn dort
`.github/workflows/org-release-actions.yml` durch die neue Template-Version
ersetzt wurde - die zusaetzlichen Trigger-Typen stehen im Template, nicht im
wiederverwendbaren Workflow. Der bestehende Template-Hash-Check warnt
entsprechend.

Nicht umgesetzt: `converted_to_draft` setzt das Ticket nicht wieder zurueck,
`reopened` wird ebenfalls nicht behandelt.