### PR TITLE
[bugfix] QR-Code-Kommentar für Android Produktiv-Builds am Release-Ticket.

### DIFF
--- a/.github/workflows/jira-android-build.yml
+++ b/.github/workflows/jira-android-build.yml
@@ -9,7 +9,7 @@ on:
         description: 'Name and extension of the QR code file'
         type: string
         default: 'android_url.png'
-      jira-ticket-id:
+      ticket-id:
         description: 'If provided, ticket IDs found in commit messages are ignored'
         type: string
         default: ''

--- a/.github/workflows/jira-android-build.yml
+++ b/.github/workflows/jira-android-build.yml
@@ -13,6 +13,10 @@ on:
         description: 'If provided, ticket IDs found in commit messages are ignored'
         type: string
         default: ''
+      release-version:
+        description: 'If provided, the comment is posted to the release ticket of this version instead of the tickets from commit messages'
+        type: string
+        default: ''
 jobs:
   jira-android-build:
     name: Comment on new Android build
@@ -56,6 +60,11 @@ jobs:
           CI_TICKET_ID: '${{ inputs.ticket-id }}'
           CI_ANDROID_URL: '${{ inputs.android-url }}'
           CI_ANDROID_QRCODE: '${{ inputs.qrcode-filename }}'
+          CI_RELEASE_VERSION: '${{ inputs.release-version }}'
+          CI_PROJECT: '${{ vars.PROJECT }}'
+          CI_VERSION_TEMPLATE: '${{ vars.VERSION_TEMPLATE }}'
+          CI_YOUTRACK_URL: '${{ vars.YOUTRACK_URL }}'
+          CI_YOUTRACK_TOKEN: '${{ secrets.YOUTRACK_TOKEN }}'
       - name: Post Comment
         uses: ./ci-scripts/actions/issue-comment
         with:

--- a/build_android_comment.py
+++ b/build_android_comment.py
@@ -9,10 +9,13 @@
 
 import os
 import json
+import sys
+from string import Template
 
 import qrcode
 
 from common import retrieve_commits, group_by_issue
+from youtrack import YouTrack
 
 
 AUTHOR_NAME = 'CI_AUTHOR_NAME'
@@ -25,6 +28,11 @@ PROJECT_DIR = 'CI_PROJECT_DIR'
 TICKET_ID = 'CI_TICKET_ID'
 ANDROID_URL = 'CI_ANDROID_URL'
 ANDROID_QRCODE = 'CI_ANDROID_QRCODE'
+RELEASE_VERSION = 'CI_RELEASE_VERSION'
+PROJECT = 'CI_PROJECT'
+VERSION_TEMPLATE = 'CI_VERSION_TEMPLATE'
+YOUTRACK_URL = 'CI_YOUTRACK_URL'
+YOUTRACK_TOKEN = 'CI_YOUTRACK_TOKEN'
 
 
 def convert_to_comment(author_name, project_name, repo_url, branch_name,
@@ -36,24 +44,57 @@ def convert_to_comment(author_name, project_name, repo_url, branch_name,
             f'![]({android_qrcode})')
 
 
+def convert_to_release_comment(release_version, android_qrcode):
+    return (f'Android Produktiv-Build Version {release_version}\n'
+            f'\n'
+            f'![]({android_qrcode}){{width=184px}}')
+
+
+def find_release_issues(env):
+    fix_version = Template(env[VERSION_TEMPLATE]).safe_substitute(
+        version=env[RELEASE_VERSION])
+    query = (f'project: {{{env[PROJECT]}}} '
+             f'tag: {{Public Release}} '
+             f'Fix versions: {{{fix_version}}}')
+    issues = YouTrack(env[YOUTRACK_URL], env[YOUTRACK_TOKEN]).issue_search(query)
+    if not issues:
+        _warn(f'no release ticket found for query `{query}`')
+    elif len(issues) > 1:
+        _warn(f'multiple release tickets found for query `{query}`: '
+              + ', '.join(issues))
+    return issues
+
+
+def _warn(msg):
+    prefix = '::warning::' if os.environ.get('CI') else 'WARNING: '
+    print(f'{prefix}{msg}', file=sys.stderr)
+
+
 def create_comments():
     env = os.environ
-    if env[TICKET_ID]:
-        affected_issues = [env[TICKET_ID]]
+    if env.get(RELEASE_VERSION):
+        affected_issues = find_release_issues(env)
+        comment = convert_to_release_comment(
+            env[RELEASE_VERSION],
+            env[ANDROID_QRCODE],
+        )
     else:
-        all_commits = retrieve_commits(
-            env[PROJECT_DIR],
-            'HEAD~' + env[NUM_COMMITS],
-            env[CUR_COMMIT])
-        affected_issues = group_by_issue(all_commits).keys()
-    comment = convert_to_comment(
-        env[AUTHOR_NAME],
-        env[PROJECT_NAME],
-        env[REPO_URL],
-        env[BRANCH_NAME],
-        env[ANDROID_URL],
-        env[ANDROID_QRCODE],
-    )
+        if env[TICKET_ID]:
+            affected_issues = [env[TICKET_ID]]
+        else:
+            all_commits = retrieve_commits(
+                env[PROJECT_DIR],
+                'HEAD~' + env[NUM_COMMITS],
+                env[CUR_COMMIT])
+            affected_issues = group_by_issue(all_commits).keys()
+        comment = convert_to_comment(
+            env[AUTHOR_NAME],
+            env[PROJECT_NAME],
+            env[REPO_URL],
+            env[BRANCH_NAME],
+            env[ANDROID_URL],
+            env[ANDROID_QRCODE],
+        )
 
     qrcode.make(env[ANDROID_URL]).save(env[ANDROID_QRCODE])
     


### PR DESCRIPTION
Wird u.a. für MID-579 benötigt.